### PR TITLE
商品出品機能（複数枚投稿実装）

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -57,33 +57,3 @@ $(function(){
     if ((targetIndex == limitFileField ) || ($(".js-file_group").length >= 9)) ($('#image-box').append(buildFileField(fileIndex)));
   });
 });
-
-// $(document).on('turbolinks:load', ()=> {
-//   // 画像用のinputを生成する関数
-//   const buildFileField = (index)=> {
-//     const html = `<div data-index="${index}" class="js-file_group">
-//                     <input class="js-file" type="file"
-//                     name="product[images_attributes][${index}][src]"
-//                     id="product_images_attributes_${index}_src"><br>
-//                     <div class="js-remove">削除</div>
-//                   </div>`;
-//     return html;
-//   }
-
-//   // file_fieldのnameに動的なindexをつける為の配列
-//   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
-
-//   $('#image-box').on('change', '.js-file', function(e) {
-//     // fileIndexの先頭の数字を使ってinputを作る
-//     $('#image-box').append(buildFileField(fileIndex[0]));
-//     fileIndex.shift();
-//     // 末尾の数に1足した数を追加する
-//     fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
-//   });
-
-//   $('#image-box').on('click', '.js-remove', function() {
-//     $(this).parent().remove();
-//     // 画像入力欄が0個にならないようにしておく
-//     if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
-//   });
-// });

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -33,7 +33,6 @@
         .js-file_group{"data-index" => "#{@item.item_images.count}"}
           = file_field_tag :src, name: "item[images_attributes][#{@item.item_images.count}][src]", class: 'js-file'
           .js-remove 削除
-
     .category
       カテゴリー
       %span.form-group_require 必須

--- a/app/views/posts/_footer.html.haml
+++ b/app/views/posts/_footer.html.haml
@@ -39,7 +39,7 @@
   .footer_logo
     = link_to image_tag 'logo-white.png', size: '160x46'
     %p ©️FURIMA
-= link_to "#" do
+= link_to new_item_path do
   .purchase-btn
     %span.purchase-btn_text 出品する
     = image_tag 'icon_camera.png', size: "54x54"


### PR DESCRIPTION
■what
商品出品の際に複数枚の画像を投稿できる機能を実装

■why
商品を様々な角度や大きさで撮ったものを表示することができるようになり、より商品に対する情報を正確に伝えることができるようになるため。